### PR TITLE
Trust casks explicitly, and document the remote-session apply hang

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,10 +234,46 @@ apply.
 ### The install-packages script must never run `brew trust` (D8)
 
 Trusting a third-party tap authorises it to run arbitrary install code. That stays a
-deliberate, manual, per-machine act; `~/.homebrew/trust.json` is not repo-managed. On an
-untrusted machine `brew bundle` prints a warning and skips the outdatedness check for that
-formula — it still installs. The README lists the `brew trust --formula …` commands to run by
-hand.
+deliberate, manual, per-machine act; `~/.homebrew/trust.json` is not repo-managed. The README
+lists the `brew trust` commands to run by hand.
+
+**Untrusted still installs — but only for fully-qualified names.** This is the load-bearing
+detail, and `brew doctor`'s wording obscures it. Doctor says *"Homebrew is currently ignoring
+formulae, casks and commands from these taps"*, which sounds absolute. It is not: what an
+untrusted tap loses is **name resolution**, not installability.
+[docs.brew.sh/Tap-Trust](https://docs.brew.sh/Tap-Trust) is explicit —
+
+> An untrusted tap is not loaded when tap trust is required unless you explicitly install a
+> fully qualified formula or cask from that tap.
+
+Homebrew's own source agrees: `Library/Homebrew/bundle/brew.rb` comments that *"fully
+qualified tap formulae can be checked by their Cellar rack name without loading the formula
+from an untrusted tap,"* and its untrusted branch emits `opoo "Cannot check whether … is
+outdated"` then returns early — warn, skip the outdatedness check, proceed.
+
+So in a Brewfile, **always write tapped entries fully qualified**:
+
+```
+brew "eth-p/software/bat-extras-batman"     # resolves untrusted
+cask "1password/tap/1password-cli"          # resolves untrusted
+cask "1password-cli"                        # NEEDS the tap loaded — fails untrusted
+```
+
+An unqualified token cannot even be trusted in advance: both `bundle/brew.rb` and
+`bundle/cask.rb` guard their trust calls with `if … Utils.full_name?(…)`, commented *"only
+fully-qualified names map to a tap, so unqualified tokens cannot be meaningfully trusted."*
+Every tapped entry in this repo is fully qualified; keep it that way.
+
+**Trust is per-kind.** `brew trust` takes `--formula`, `--cask`, `--command`, or a bare tap
+name. `--formula` does not cover a cask from the same tap. An already-installed but untrusted
+cask keeps working — its binaries are on disk — so the only symptom is that `brew outdated`
+silently skips it. That is how `1password-cli` sat untrusted here unnoticed.
+
+**Do not use the Brewfile `trusted:` option.** `tap`, `brew` and `cask` entries accept
+`trusted: true`, which writes the trust entry before installing. It would make the warning go
+away in one line, and adopting it would invert D8 — the point is that a dotfiles clone must
+not hand out trust on your behalf. `brew bundle dump` emits it for already-trusted entries;
+strip it if you ever re-dump.
 
 `--no-upgrade` is also passed explicitly on every layer, deliberately: a bare `brew bundle
 install` upgrades everything outdated. Applying dotfiles should converge the *declared set*;
@@ -287,10 +323,75 @@ Two details that are easy to get wrong:
   fail with "multiple accounts found."
 - `lookPath "op"` proves only that the binary exists, not that the vault is unlocked. If op is
   locked, the read fails and the whole apply fails. `onepassword.prompt = false` in the
-  per-machine config makes that a legible error rather than a hang.
+  per-machine config makes that a legible error rather than a hang. Two shapes of that error,
+  both measured on czimacos6457 2026-08-07:
+
+  | State | Result | Latency |
+  | --- | --- | --- |
+  | signed out | `[ERROR] … account is not signed in`, exit 1 | ~1s |
+  | unlock prompt dismissed or failed | `[ERROR] … response: promptError`, exit 1 | ~1s |
+  | unlock prompt raised, unanswered | `[ERROR] … authorization timeout`, exit 1 | ~90s |
+
+  So "legible rather than a hang" is right, but **not necessarily prompt** — op waits out its
+  own authorization timeout before giving up, and chezmoi sits there the whole time. Do not
+  conclude a command is wedged until you have given it two minutes. Note also that op
+  re-locks on its own, so a long working session can start erroring part-way through; unlock
+  and re-run. **This guarantee covers a locked vault only** — see the next section for a
+  failure mode it cannot save you from.
 
 `private_` must stay on the **filename**. Do not hoist it to a `private_dot_config/`
 directory — two source entries mapping to `~/.config` is a source-state conflict.
+
+### When `chezmoi status` hangs, suspect macOS, not chezmoi
+
+Diagnosed on czimacos6457 2026-08-07. In a session driven by a **remote client**, bare
+`chezmoi status`, `diff` and `apply` can hang forever, printing nothing.
+
+The cause is macOS's app-data consent gate — the *"«App» wants to access data from other
+apps"* dialog. `open()` on a third-party group container under `~/Library/Group Containers/`
+does not fail when consent is missing; it **blocks indefinitely** waiting for a dialog that
+renders on the physical console. `stat` still succeeds, so the directory looks fine.
+
+The chain: `op` reaches 1Password's desktop CLI integration through a socket under
+`2BUA8C4S2C.com.1password/` → blocks in `open()` → `onepasswordRead` never returns → and
+because chezmoi computes target state for the **whole tree** before printing anything, one
+wedged template stalls every command.
+
+`onepassword.prompt = false` cannot help here. It governs only whether chezmoi shells out to
+`op signin`; this block is in the kernel, one layer below `op`.
+
+**Diagnose in one command** — this hangs too, which proves it is not chezmoi:
+
+```sh
+ls ~/Library/Group\ Containers/2BUA8C4S2C.com.1password
+```
+
+Not 1Password-specific: every un-consented third-party team-ID container behaves this way
+(Todoist and WS1 Hub were also confirmed). Apple's `group.com.apple.*` containers do not.
+
+**Work around it** by path-scoping away from the secrets template, which skips the `op` call:
+
+```sh
+chezmoi status ~/.config/homebrew
+chezmoi diff ~/.zshrc
+```
+
+**Fix it** by granting the consent once at the console, or by giving the client app Full Disk
+Access (System Settings → Privacy & Security), which supersedes app-data gating for every
+container. A full `apply` is not available remotely until one of those is done.
+
+Beware when timing this out: macOS ships no `timeout(1)`. For C programs — including the `ls`
+probe above — `perl -e 'alarm 10; exec @ARGV' <cmd>` works, and exit 142 means it hung. It
+does **not** work on `chezmoi` or `op`: both are Go, and the Go runtime handles `SIGALRM`
+itself rather than dying on it, so the alarm is swallowed and you wait the full time anyway.
+For those, background the command and `kill -9` it, then read its output file.
+
+To see what a blocked process is actually waiting on, sample it — this is what identified the
+gate as an `open()` block rather than anything in chezmoi or op:
+
+```sh
+<cmd> & pid=$!; sample $pid 2 -file /tmp/s.txt; kill -9 $pid; grep -E '^ +[0-9]+ ' /tmp/s.txt
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,15 @@ Some Homebrew packages have caveats and follow-up work of their own; see [`runbo
 
 ## Trusting taps
 
-Homebrew will not load a formula from a non-official tap until that tap has been trusted, and it cannot check whether
-such a formula is outdated. Trust is recorded in `~/.homebrew/trust.json`, which is **deliberately not managed by this
-repo**: trusting a tap authorises it to run arbitrary code at install time, so it stays a conscious, per-machine act
-rather than something a dotfiles clone hands out on your behalf. The install script never calls `brew trust`.
+Homebrew will not load anything from a non-official tap until it has been trusted, and it cannot check whether such an
+entry is outdated. Trust is recorded in `~/.homebrew/trust.json`, which is **deliberately not managed by this repo**:
+trusting a tap authorises it to run arbitrary code at install time, so it stays a conscious, per-machine act rather
+than something a dotfiles clone hands out on your behalf. The install script never calls `brew trust` (D8).
+
+**Casks need trusting too, and they need a different flag.** `brew trust` takes `--formula`, `--cask`, `--command`, or
+a bare tap name for whole-tap trust; `--formula` does *not* cover a cask from the same tap. This is easy to miss,
+because a cask that is already installed keeps working perfectly while untrusted — its binaries are on disk and run
+fine. What you silently lose is upgrade visibility (`brew outdated` skips it) and installability on a fresh Mac.
 
 The cost is that every new Mac needs these run by hand:
 
@@ -92,35 +97,72 @@ The cost is that every new Mac needs these run by hand:
 # base layer — every machine
 brew trust --formula eth-p/software/bat-extras-batman
 brew trust --formula anomalyco/tap/opencode
+brew trust --cask    1password/tap/1password-cli
 
 # role = work
 brew trust --formula chanzuckerberg/tap/argus
 brew trust --formula chanzuckerberg/tap/aws-oidc
+
+# role = personal
+brew trust --cask    deskflow/tap/deskflow
 ```
 
-Nothing is needed for the casks (`1password-cli`, `deskflow`) or for the `role = personal` layer.
+Casks from official taps (`ghostty`, `git-credential-manager`, the fonts, `kap`, `claude-code`, `monitorcontrol`) need
+nothing.
 
 Check the result:
 
 ```sh
 brew trust --json v1                                     # what is currently trusted
+brew doctor                                              # warns per-TAP, see below
 brew bundle check --file="$HOME/.config/homebrew/Brewfile"
 ```
 
-Until the commands above are run, `brew bundle check` prints one warning per untrusted formula and reports it as
-unsatisfied:
+`brew doctor` warns at **tap** granularity, not per entry — a tap disappears from the warning as soon as *one* of its
+entries is trusted:
+
+```
+Warning: The following taps are not trusted:
+  1password/tap
+```
+
+So a green-ish `brew doctor` does not mean every entry in the Brewfiles is trusted. `brew trust --json v1` is the
+authoritative view; check it against the command list above.
+
+Until the commands above are run, `brew bundle check` prints one warning per untrusted entry, and reports it as
+unsatisfied if it is not already installed:
 
 ```
 Warning: Cannot check whether eth-p/software/bat-extras-batman is outdated because its tap is not trusted.
          Run `brew trust --formula eth-p/software/bat-extras-batman` to trust it.
 ```
 
-**`man` is affected.** `dot_zshrc` sets `alias man='batman'`, and `batman` comes from
-`eth-p/software/bat-extras-batman`. On a machine where that formula has not been trusted, `man` is broken. It is the
-first thing you'll notice and the last thing you'll think to blame on Homebrew.
+`brew doctor` says it is *"ignoring formulae, casks and commands from these taps"*, which sounds absolute but is not.
+Per [the Tap Trust docs](https://docs.brew.sh/Tap-Trust), *"an untrusted tap is not loaded … unless you explicitly
+install a fully qualified formula or cask from that tap."* What an untrusted tap loses is **name resolution**, so a
+fully-qualified entry (`brew "eth-p/software/bat-extras-batman"`) still installs untrusted, and only its outdatedness
+check is skipped. Every tapped entry in the Brewfiles is written fully qualified for exactly this reason — don't
+shorten one to its bare token.
 
-If a new tapped formula is ever added to a Brewfile, add its `brew trust --formula` line to this section at the same
-time.
+**Two things break in ways you will not blame on Homebrew:**
+
+* **`man`.** `dot_zshrc` sets `alias man='batman'`, and `batman` comes from `eth-p/software/bat-extras-batman`. On a
+  machine where that formula has not been trusted, `man` is broken.
+* **The whole `chezmoi apply`.** `private_secrets.zsh.tmpl` calls `onepasswordRead`, so a work machine without a
+  working `op` fails the apply outright — and `op` is `1password-cli`, the cask above.
+
+### Leftover taps
+
+Uninstalling a package does not untap its tap, and neither does `brew bundle install` — it only ever adds. So removing
+the last package from a tap leaves the tap behind, where it is inert but shows up in `brew tap` and trips the
+`brew doctor` warning above. Clean up by hand:
+
+```sh
+brew untap <user>/<tap>
+```
+
+If a new tapped formula or cask is ever added to a Brewfile, add its `brew trust --formula` / `--cask` line to the list
+above at the same time.
 
 ## Daily use
 
@@ -152,7 +194,7 @@ exit
 
 **Read this before you go looking for a bug.** This repo uses chezmoi's default *copy* mode: `~/.zshrc` and friends
 are real files, not symlinks into the repo. That is a deliberate choice, but it has one sharp edge, and it is the
-single biggest behavioural difference from the old symlink-based setup.
+single biggest behavioral difference from the old symlink-based setup.
 
 **A program that rewrites its own config writes to the copy, and the next `chezmoi apply` silently reverts it.**
 
@@ -274,7 +316,17 @@ The mechanics:
 Tradeoffs worth knowing: the plaintext sits on disk at `0600` between applies (the shell pays no 1Password cost at
 startup); a value rotated in 1Password does not propagate until the next `chezmoi apply`; and if the vault is locked,
 `onepasswordRead` fails, which aborts the *entire* apply rather than just that file. `onepassword.prompt = false` is
-set so that failure is an immediate legible error instead of a hang.
+set so that failure is a legible error instead of a hang — though not always a fast one. Signed out, `op` errors in
+about a second; if an unlock prompt is raised and left unanswered it waits out its authorization timeout first, so
+`chezmoi` can sit silent for ~90s before reporting. `op` also re-locks on its own after a while, so a long session can
+start erroring mid-way through — unlock and re-run.
+
+**If a chezmoi command hangs instead of erroring, it is not chezmoi.** In a session driven by a remote client, macOS
+app-data consent makes `open()` on 1Password's group container block forever waiting for a dialog on the physical
+console, and `op` — and therefore every chezmoi command — blocks with it. `onepassword.prompt` cannot help; the block
+is below `op`. Confirm with `ls ~/Library/Group\ Containers/2BUA8C4S2C.com.1password`, which hangs the same way. Work
+around it by path-scoping (`chezmoi status ~/.config/homebrew`); fix it by granting the consent at the console or
+giving the client app Full Disk Access. Full detail in [AGENTS.md](AGENTS.md).
 
 A pre-commit hook in `.githooks/` scans staged content for credential-shaped strings — built-in patterns first, then
 `gitleaks` when it is installed, configured by [`.gitleaks.toml`](.gitleaks.toml). It is wired up by

--- a/dot_config/homebrew/Brewfile
+++ b/dot_config/homebrew/Brewfile
@@ -75,8 +75,14 @@ brew "fzf"
 brew "tree" # used to preview directories, and a generally useful utility
 
 # 1Password CLI
+# Fully qualified on purpose (D8). An untrusted tap is not *loaded*, so a bare
+# `cask "1password-cli"` cannot be resolved on a machine that has not run
+# `brew trust --cask 1password/tap/1password-cli`; the qualified form installs
+# anyway and only loses its outdatedness check. This one matters more than the
+# rest: private_secrets.zsh.tmpl calls onepasswordRead, so a work machine with no
+# `op` fails the whole apply. Trusted on czimacos6457 on 2026-08-07.
 tap "1Password/tap"
-  cask "1password-cli"
+  cask "1password/tap/1password-cli"
 
 # fnm - Fast Node Manager (replacement for nvm)
 brew "fnm"

--- a/dot_config/zsh/private_secrets.zsh.tmpl
+++ b/dot_config/zsh/private_secrets.zsh.tmpl
@@ -23,6 +23,13 @@ Three things about this file are deliberate (D6, D7, §5):
     not just this file. onepassword.prompt = false in the config makes that a
     legible error rather than a hang. Applies are expected to be interactive.
 
+    That "rather than a hang" holds for a LOCKED VAULT only (verified 2026-08-07:
+    locked, `op whoami` errors and exits 1 in about a second). It does not hold in a
+    session driven by a remote client, where macOS app-data consent makes op block
+    in open() forever on 1Password's group container and takes every chezmoi command
+    down with it — this file is the one that triggers it. See "When chezmoi status
+    hangs, suspect macOS, not chezmoi" in AGENTS.md.
+
 The secret is fetched at APPLY time and written to disk, not read at shell startup.
 So the shell pays no 1Password cost, but the plaintext does sit at 0600 between
 applies, and rotating the value in 1Password requires `chezmoi apply` to propagate.


### PR DESCRIPTION
Two findings from chasing a `brew doctor` warning about untrusted taps.

`brew trust` takes --formula, --cask, --command or a bare tap name, and --formula does not cover a cask from the same tap. Every trust command in the README was --formula, and 1password-cli was absent from the list entirely, so it was never trusted. An installed-but-untrusted cask keeps working, which is why this went unnoticed: the only symptom is that `brew outdated` silently skips it.

The base Brewfile also referenced that cask by bare token. Per docs.brew.sh/Tap-Trust an untrusted tap is not loaded "unless you explicitly install a fully qualified formula or cask from that tap", so what an untrusted tap loses is name resolution, not installability. Every other tapped entry here was already fully qualified; this one would have failed to resolve on a fresh untrusted Mac, taking out `op` and with it the apply that renders private_secrets.zsh.tmpl. Qualify it.

D8 is unchanged and the scripts still never call `brew trust`. Note that Brewfiles now accept `trusted: true`, which would invert that decision -- recorded as deliberately unused.

Separately: the claim that onepassword.prompt = false turns a locked vault into "a legible error rather than a hang" is correct, but was doing more work than it could support. It says nothing about latency (op waits out a ~90s authorization timeout when a prompt goes unanswered), and nothing about the case where the block is below op entirely. In a remote-client session, macOS app-data consent makes open() on 1Password's group container block indefinitely on a dialog that renders at the console; chezmoi computes whole-tree target state before printing, so every command hangs silently. Scope the claim, add the measured error shapes, and document the one-line probe that tells the two apart.