### PR TITLE
Move summarize from the base Brewfile to the personal role

### DIFF
--- a/dot_config/homebrew/Brewfile
+++ b/dot_config/homebrew/Brewfile
@@ -122,4 +122,3 @@ cask "kap"
 # AI
 cask "claude-code"
 brew "anomalyco/tap/opencode"
-brew "summarize"

--- a/dot_config/homebrew/Brewfile.role-personal
+++ b/dot_config/homebrew/Brewfile.role-personal
@@ -34,3 +34,7 @@ cask "mkvtoolnix-app"
 # to the base Brewfile is the whole change.
 tap "deskflow/tap"
   cask "deskflow/tap/deskflow"
+
+# AI
+# Multi-modal AI summarizer.
+brew "summarize"


### PR DESCRIPTION
Contributed to base by iris. The tool itself is fine anywhere; its dependency closure is not. summarize depends on ffmpeg, node, tesseract and yt-dlp, and ffmpeg and yt-dlp were deliberately moved off czimacos6457 on 2026-08-06 and declared in Brewfile.role-personal.

Declaring summarize in base therefore reinstalls them on every work machine through the dependency graph, reversing that decision without touching the file that records it. On czimacos6457 the marginal cost measured 55 formulae, including a Homebrew node alongside the fnm-managed one. The layer model guards declarations, not closures, so nothing in the tree would have caught this.

Base is documented as cross-machine essentials only, and iris already puts its comparable experiments in its machine overlay. role-personal keeps summarize on the machines that want the media stack anyway.

container and qemu, added to base by the same commit, are kept there deliberately.

Verified on czimacos6457: full apply installs pwgen, container, qemu, uv and pstree only; ffmpeg, yt-dlp, node and tesseract remain absent; brew_bundle_audit reports no packages outside the effective Brewfile. Rendered role=personal/machine=iris into a scratch tree to confirm summarize still lands there.