### PR TITLE
Run brew_bundle_audit under uv with a declared Python floor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,6 +428,23 @@ chezmoi doctor
 
 Add `--source="$PWD"` to all of the above if `chezmoi source-path` is not this checkout.
 
+### The `brew_bundle_audit` unit tests
+
+`dot_local/bin/executable_brew_bundle_audit` is the one source entry with tests. Run them
+directly — the file is executable and carries a `uv run --script` shebang:
+
+```sh
+./runbooks/tests/test_brew_bundle_audit.py
+```
+
+Both that file and the script declare `requires-python = ">=3.11"` in a PEP 723 block, because
+the script needs `tomllib` and `#!/usr/bin/env python3` can resolve to the 3.9.6 Xcode CLT stub
+on a stripped-down `$PATH`. It is a **floor, not a pin**: uv reuses an already-installed
+interpreter satisfying it and downloads nothing, so the two files are guaranteed to be ≥3.11
+but not guaranteed to be the *same* interpreter. Restate the block in both files if it changes —
+the test `exec_module()`s the script, so the script's own shebang is never consulted, and
+`python3 -m unittest discover` bypasses the floor entirely by choosing the interpreter itself.
+
 **Test the per-machine matrix when you touch anything role- or machine-gated.** Varying
 `.role` and `.machine` is the feature being bought; exercise both values and confirm the git
 email, the personal-only KDE credential block, the shared Azure GCM default, the secrets file

--- a/dot_local/bin/executable_brew_bundle_audit
+++ b/dot_local/bin/executable_brew_bundle_audit
@@ -1,4 +1,19 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+#
+# This needs 3.11+ for tomllib.  A bare `#!/usr/bin/env python3` shebang does not
+# say that — it resolves to whatever is first on $PATH, and on a stripped-down
+# PATH (launchd, cron, a non-login ssh shell) that is /usr/bin/python3, which is
+# the 3.9.6 Xcode CLT stub and dies at `import tomllib`.  The PEP 723 block above
+# makes uv enforce the floor before the first line runs.
+#
+# Deliberately a floor and not a pin: uv reuses any installed interpreter that
+# satisfies it — today Homebrew's python@3 — rather than downloading a managed
+# CPython, so this adds no per-machine state outside the repo.  Costs ~30ms once
+# uv's env cache is warm.  Keep this in sync with the same block in
+# runbooks/tests/test_brew_bundle_audit.py.
 """Audit installed Homebrew packages against this machine's effective Brewfile.
 
 The report is deliberately read-only.  Its primary classification uses current

--- a/runbooks/tests/test_brew_bundle_audit.py
+++ b/runbooks/tests/test_brew_bundle_audit.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+#
+# The same floor as the script under test, for a different reason.  This file
+# loads the script with SourceFileLoader.exec_module(), so `import tomllib` runs
+# in *this* interpreter and the script's own shebang is never consulted — the
+# floor has to be restated here or the tests can be run under a Python the script
+# could not survive.
+#
+# That only holds if this file is executed directly:
+#
+#     ./runbooks/tests/test_brew_bundle_audit.py
+#
+# `python3 -m unittest discover -s runbooks/tests` still works, but it chooses the
+# interpreter on the command line and never reads the block above, so it bypasses
+# the floor.  Prefer the direct form.
 """Focused unit tests for the receipt-independent Homebrew audit graph."""
 
 from __future__ import annotations
@@ -16,6 +34,16 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "dot_local" / "bin" / "executable_brew_bundle_audit"
+
+# exec_module() below writes a bytecode cache next to SCRIPT, i.e. into
+# dot_local/bin/__pycache__/ in the source tree.  That directory has no chezmoi
+# prefix, so chezmoi treats it as a source entry and materialises it as
+# ~/.local/bin/__pycache__/ on the next apply.  A .gitignore rule would not help:
+# chezmoi builds source state from the working tree, not from git's index.  And
+# because dot_local/bin is deliberately not exact_ (R1), the junk would never be
+# cleaned up again.  Suppress the write instead of ignoring the artefact.
+sys.dont_write_bytecode = True
+
 LOADER = importlib.machinery.SourceFileLoader("brew_bundle_audit", str(SCRIPT))
 SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
 assert SPEC is not None


### PR DESCRIPTION
The script imports tomllib, which needs 3.11+, but #!/usr/bin/env python3 does not say that — it resolves to whatever is first on $PATH. On this machine that is Homebrew's 3.14.6 and the script works; on a stripped-down PATH (launchd, cron, a non-login ssh shell) it is /usr/bin/python3, the 3.9.6 Xcode CLT stub, and the script dies at `import tomllib`. Confirmed:

    $ /usr/bin/python3 dot_local/bin/executable_brew_bundle_audit --help
    ModuleNotFoundError: No module named 'tomllib'

brew "python@3" is an alias that floats, too, so nothing recorded which interpreter the script was actually tested against. The Brewfile already carries a comment warning that python3 on PATH is not necessarily that formula's version.

uv is already in the base Brewfile, so a PEP 723 block plus a `uv run --script` shebang turns the implicit PATH assumption into a declaration the runtime enforces before the first line executes. The script has no third-party dependencies; what uv buys here is interpreter selection, not dependency resolution.

Deliberately a floor (>=3.11) and not a pin (==3.13.*). A floor makes uv reuse an already-installed interpreter that satisfies it — measured: it picked Homebrew's 3.14 and downloaded nothing, leaving ~/.local/share/uv/ python empty. A pin would download a managed 24 MiB CPython per machine, which is real independence from Homebrew but also unversioned per-machine state invisible to chezmoi status. The residual cost of the floor is that the script and its tests are each guaranteed >=3.11 but not guaranteed to be the same interpreter; both resolve to 3.14 today. Warm overhead of the uv indirection measured at ~30ms on --help, against a tool that then shells out to brew info.

The test file needs the same block for a different reason: it loads the script with SourceFileLoader.exec_module(), so `import tomllib` runs in the test's interpreter and the script's own shebang is never consulted. Without the floor restated there the suite could pass under a Python the script could not survive. That only holds if the file is executed directly, hence the mode change to 755 — `python3 -m unittest discover` chooses the interpreter on the command line and never reads the block.

Running those tests also turned out to drop a bytecode cache into dot_local/bin/__pycache__/ in the source tree, which has always been true and was never noticed because the tests were undocumented. That directory has no chezmoi prefix, so chezmoi treats it as a source entry and materialises ~/.local/bin/__pycache__/ on the next apply; chezmoi status was reporting it as pending. A .gitignore rule would not have helped, because chezmoi builds source state from the working tree rather than git's index, and because dot_local/bin is deliberately not exact_ (R1) the junk would never have been cleaned up. Fixed at the root with sys.dont_write_bytecode rather than by ignoring the artefact.

AGENTS.md gains a short subsection recording how to run the tests and why the floor is stated twice; nothing documented either before.

Verified on czimacos6457: full chezmoi apply exit 0, status and verify both silent and exit 0, 19 tests pass via the direct invocation, no __pycache__ regenerated in the source tree or $HOME, ~/.local/bin holds only the two managed scripts, and brew_bundle_audit --help runs from $PATH.